### PR TITLE
Scale parameter when updating psijh

### DIFF
--- a/spfactcovest_mgploadings.m
+++ b/spfactcovest_mgploadings.m
@@ -96,7 +96,7 @@ for g = 1:rep
         end
 
         %------Update psi_{jh}'s------%
-        psijh = gamrnd(df/2 + 0.5,1./(df/2 + bsxfun(@times,Lambda.^2,tauh')));
+        psijh = gamrnd(df/2 + 0.5,2./(df + bsxfun(@times,Lambda.^2,tauh')));
 
         %------Update delta & tauh------%
         mat = bsxfun(@times,psijh,Lambda.^2);


### PR DESCRIPTION
Since the rate parameter for conditional of psijh is (\nu + \tau_h *\lambda_{jh}^2)/2, I think the scale parameter of gamrnd() should be "2./(df + bsxfun(@times,Lambda.^2,tauh'))" instead of "1./(df/2 + bsxfun(@times,Lambda.^2,tauh'))".